### PR TITLE
feat: add devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,16 @@
 {
   description = "Nix unit";
 
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-  };
+  inputs = { nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable"; };
 
   outputs = { self, nixpkgs }: {
     nixosModules.default = import ./module.nix;
+
+    devShells.x86_64-linux.default =
+      let pkgs = import nixpkgs { system = "x86_64-linux"; };
+      in pkgs.mkShell {
+        packages =
+          [ (import ./src/nixunits.nix { inherit (pkgs) lib stdenv pkgs; }) ];
+      };
   };
 }


### PR DESCRIPTION

Add a `devShells` attribute,  the development environment can be use with `nix develop` command
